### PR TITLE
Fixed getConfig

### DIFF
--- a/bin/punit
+++ b/bin/punit
@@ -50,7 +50,7 @@ function getConfig()
 
     foreach (['punit.php.dist', 'punit.php'] as $fileName) {
         if (file_exists($fileName)) {
-            $config = array_merge_recursive($config, require_once($fileName));
+            $config = array_replace_recursive($config, require_once($fileName));
         }
     }
     return $config;


### PR DESCRIPTION
- Loads punit.php(.dist)
- Requires autoload
- Fixed punit.php.dist syntax
- Replaced `array_merge_recursive`  with `array_replace_recursive` from previous request